### PR TITLE
fix(config): look for config file as .ghit.toml in home directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
 impl Config {
     pub fn load() -> Result<Self> {
         let mut path: PathBuf = dirs::home_dir().context("could not find home directory")?;
-        path.push("ghit.toml");
+        path.push(".ghit.toml");
 
         let s = fs::read_to_string(&path)
             .with_context(|| format!("failed to read {}", path.display()))?;


### PR DESCRIPTION
Change config file name from 'ghit.toml' to '.ghit.toml' to follow convention for hidden files in home directory.

### Current behavior 
With a `~/.ghit.toml` 
<img width="615" alt="image" src="https://github.com/user-attachments/assets/3dad948e-d9b8-4d24-9e57-8476943e51eb" />

### After fix
It created this commit! 

<img width="980" alt="image" src="https://github.com/user-attachments/assets/d3298d50-194d-4363-a782-8d1507e48495" />
